### PR TITLE
comment out fetch to slack to temporarily stop bot messages

### DIFF
--- a/src/utils/slackMessages.ts
+++ b/src/utils/slackMessages.ts
@@ -13,6 +13,7 @@ export function postHotStreak(wins: number, name: string) {
 
     // TODO - more variety of messages?
 
+    /*
     fetch('https://slack.com/api/chat.postMessage', {
       method: 'POST',
       body: JSON.stringify(message),
@@ -21,5 +22,6 @@ export function postHotStreak(wins: number, name: string) {
         Authorization: `Bearer ${env.SLACK_AUTH_TOKEN}`,
       },
     });
+    */
   }
 }


### PR DESCRIPTION
Comment out the actual request to Slack API to temporarily disable slack messages on hot streaks until we can figure out a better way to give updates that don't make the channel so noisy